### PR TITLE
feature(api): Add locale-specific translation unregistering

### DIFF
--- a/api/src/main/java/net/kyori/adventure/translation/AbstractTranslationStore.java
+++ b/api/src/main/java/net/kyori/adventure/translation/AbstractTranslationStore.java
@@ -141,6 +141,14 @@ public abstract class AbstractTranslationStore<T> implements TranslationStore<T>
   }
 
   @Override
+  public final void unregister(final String key, final Locale locale) {
+    this.translations.computeIfPresent(requireNonNull(key, "key"), (ignored, translation) -> {
+      translation.unregister(requireNonNull(locale, "locale"));
+      return translation.isEmpty() ? null : translation;
+    });
+  }
+
+  @Override
   public final Key name() {
     return this.name;
   }
@@ -199,6 +207,14 @@ public abstract class AbstractTranslationStore<T> implements TranslationStore<T>
       if (this.translations.putIfAbsent(requireNonNull(locale, "locale"), requireNonNull(translation, "translation")) != null) {
         throw new IllegalArgumentException(String.format("Translation already exists: %s for %s", this.key, locale));
       }
+    }
+
+    private void unregister(final Locale locale) {
+      this.translations.remove(locale);
+    }
+
+    private boolean isEmpty() {
+      return this.translations.isEmpty();
     }
 
     @Override

--- a/api/src/main/java/net/kyori/adventure/translation/TranslationStore.java
+++ b/api/src/main/java/net/kyori/adventure/translation/TranslationStore.java
@@ -167,6 +167,18 @@ public interface TranslationStore<T> extends Translator {
   void unregister(final String key);
 
   /**
+   * Unregisters a translation for a key and locale.
+   *
+   * <p>If this is the last translation registered for the key, the key is also
+   * unregistered.</p>
+   *
+   * @param key a translation key
+   * @param locale a locale
+   * @since 5.2.1
+   */
+  void unregister(final String key, final Locale locale);
+
+  /**
    * An abstract, string-based translation store.
    *
    * <p>This class extends upon the standard abstract translation store by adding

--- a/api/src/test/java/net/kyori/adventure/translation/TranslationStoreTest.java
+++ b/api/src/test/java/net/kyori/adventure/translation/TranslationStoreTest.java
@@ -38,8 +38,10 @@ import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 class TranslationStoreTest {
   static final TranslationStore.StringBased<MessageFormat> REGISTRY = TranslationStore.messageFormat(Key.key("adventure", "test"));
@@ -56,6 +58,35 @@ class TranslationStoreTest {
   @Test
   void testRegister_duplicate() {
     assertThrows(IllegalArgumentException.class, () -> REGISTRY.register("test", Locale.US, new MessageFormat("Another test.")));
+  }
+
+  @Test
+  void testUnregister_locale() {
+    final TranslationStore.StringBased<MessageFormat> store = TranslationStore.messageFormat(Key.key("adventure", "locale-unregister"));
+    final MessageFormat english = new MessageFormat("Hello", Locale.US);
+    final MessageFormat german = new MessageFormat("Hallo", Locale.GERMANY);
+    store.register("hello-world", Locale.US, english);
+    store.register("hello-world", Locale.GERMANY, german);
+
+    store.unregister("hello-world", Locale.GERMANY);
+
+    assertEquals(english, store.translate("hello-world", Locale.US));
+    assertFalse(store.contains("hello-world", Locale.GERMANY));
+    assertTrue(store.contains("hello-world"));
+  }
+
+  @Test
+  void testUnregister_locale_lastTranslation() {
+    final TranslationStore.StringBased<MessageFormat> store = TranslationStore.messageFormat(Key.key("adventure", "locale-unregister-last"));
+    final MessageFormat translation = new MessageFormat("Hello", Locale.US);
+    store.register("hello-world", Locale.US, translation);
+
+    store.unregister("hello-world", Locale.US);
+
+    assertFalse(store.contains("hello-world"));
+    assertFalse(store.contains("hello-world", Locale.US));
+    store.register("hello-world", Locale.US, translation);
+    assertEquals(translation, store.translate("hello-world", Locale.US));
   }
 
   @Test


### PR DESCRIPTION
Adds `TranslationStore#unregister(String, Locale)` to allow unregistering a translation for a specific locale without affecting the other translations for that key

Includes tests for preserving other locales and removing empty keys

Closes #1361
