### PR TITLE
fix(minimessage): preserve transformed component children when serializing gradients

### DIFF
--- a/text-minimessage/src/main/java/net/kyori/adventure/text/minimessage/MiniMessageParser.java
+++ b/text-minimessage/src/main/java/net/kyori/adventure/text/minimessage/MiniMessageParser.java
@@ -30,6 +30,7 @@ import java.util.function.BiConsumer;
 import java.util.function.Consumer;
 import java.util.function.Predicate;
 import net.kyori.adventure.text.Component;
+import net.kyori.adventure.text.VirtualComponent;
 import net.kyori.adventure.text.minimessage.internal.parser.ParsingExceptionImpl;
 import net.kyori.adventure.text.minimessage.internal.parser.Token;
 import net.kyori.adventure.text.minimessage.internal.parser.TokenParser;
@@ -38,6 +39,7 @@ import net.kyori.adventure.text.minimessage.internal.parser.node.ElementNode;
 import net.kyori.adventure.text.minimessage.internal.parser.node.RootNode;
 import net.kyori.adventure.text.minimessage.internal.parser.node.TagNode;
 import net.kyori.adventure.text.minimessage.internal.parser.node.ValueNode;
+import net.kyori.adventure.text.minimessage.internal.serializer.Emitable;
 import net.kyori.adventure.text.minimessage.tag.Inserting;
 import net.kyori.adventure.text.minimessage.tag.Modifying;
 import net.kyori.adventure.text.minimessage.tag.Tag;
@@ -188,7 +190,9 @@ record MiniMessageParser(TagResolver tagResolver) {
 
   Component parseFormat(final ContextImpl context) {
     final ElementNode root = this.parseToTree(context);
-    return Objects.requireNonNull(context.postProcessor().apply(this.treeToComponent(root, context)), "Post-processor must not return null");
+    final Component component = Objects.requireNonNull(context.postProcessor().apply(this.treeToComponent(root, context)), "Post-processor must not return null");
+    this.bindVirtualComponents(component);
+    return component;
   }
 
   Component treeToComponent(final ElementNode node, final ContextImpl context) {
@@ -252,5 +256,14 @@ record MiniMessageParser(TagResolver tagResolver) {
       newComp = newComp.append(this.handleModifying(modTransformation, child, depth + 1));
     }
     return newComp;
+  }
+
+  private void bindVirtualComponents(final Component component) {
+    if (component instanceof VirtualComponent virtualComponent && virtualComponent.renderer() instanceof Emitable emitable) {
+      emitable.bind(component);
+    }
+    for (final Component child : component.children()) {
+      this.bindVirtualComponents(child);
+    }
   }
 }

--- a/text-minimessage/src/main/java/net/kyori/adventure/text/minimessage/internal/serializer/Emitable.java
+++ b/text-minimessage/src/main/java/net/kyori/adventure/text/minimessage/internal/serializer/Emitable.java
@@ -42,6 +42,15 @@ public interface Emitable {
   void emit(final TokenEmitter emitter);
 
   /**
+   * Bind the component produced by a transformation.
+   *
+   * @param component the transformed component
+   * @since 5.2.1
+   */
+  default void bind(final Component component) {
+  }
+
+  /**
    * Provide a substitute for this component's actual children.
    *
    * <p>This allows modifying tags to output original data while still transforming the created components.</p>

--- a/text-minimessage/src/main/java/net/kyori/adventure/text/minimessage/tag/standard/AbstractColorChangingTag.java
+++ b/text-minimessage/src/main/java/net/kyori/adventure/text/minimessage/tag/standard/AbstractColorChangingTag.java
@@ -193,7 +193,17 @@ abstract class AbstractColorChangingTag implements Modifying {
   @Override
   public abstract String toString();
 
-  private record TagInfoHolder(Consumer<TokenEmitter> output, Component substitute) implements VirtualComponentRenderer<Void>, Emitable {
+  private static final class TagInfoHolder implements VirtualComponentRenderer<Void>, Emitable {
+    private final Consumer<TokenEmitter> output;
+    private final Component substitute;
+    private @Nullable Component transformed;
+    private @Nullable Component original;
+
+    TagInfoHolder(final Consumer<TokenEmitter> output, final Component substitute) {
+      this.output = output;
+      this.substitute = substitute;
+    }
+
     @Override
     public @UnknownNullability ComponentLike apply(final Void context) {
       return this.substitute;
@@ -208,6 +218,33 @@ abstract class AbstractColorChangingTag implements Modifying {
     public void emit(final TokenEmitter emitter) {
       this.output.accept(emitter);
     }
+
+    @Override
+    public Component substitute() {
+      return this.substitute;
+    }
+
+    @Override
+    public void bind(final Component component) {
+      this.transformed = component;
+      this.bindOriginals(this.substitute);
+    }
+
+    private void bindOriginals(final Component component) {
+      if (component instanceof VirtualComponent virtualComponent && virtualComponent.renderer() instanceof TagInfoHolder tagInfoHolder) {
+        if (tagInfoHolder.original == null) {
+          tagInfoHolder.original = virtualComponent;
+          tagInfoHolder.bindOriginals(tagInfoHolder.substitute);
+        }
+      }
+      for (final Component child : component.children()) {
+        this.bindOriginals(child);
+      }
+    }
+
+    boolean isTransformed(final Component component) {
+      return this.transformed == component || this.original == component;
+    }
   }
 
   static @Nullable Emitable claimComponent(final Component comp) {
@@ -220,6 +257,7 @@ abstract class AbstractColorChangingTag implements Modifying {
       return null;
     }
 
-    return tagInfoHolder;
+    final boolean transformed = tagInfoHolder.isTransformed(virtualComponent);
+    return transformed ? tagInfoHolder : null;
   }
 }

--- a/text-minimessage/src/test/java/net/kyori/adventure/text/minimessage/MiniMessageSerializerTest.java
+++ b/text-minimessage/src/test/java/net/kyori/adventure/text/minimessage/MiniMessageSerializerTest.java
@@ -23,15 +23,20 @@
  */
 package net.kyori.adventure.text.minimessage;
 
+import java.util.regex.Pattern;
 import net.kyori.adventure.key.Key;
 import net.kyori.adventure.text.Component;
+import net.kyori.adventure.text.TextReplacementConfig;
 import net.kyori.adventure.text.format.NamedTextColor;
 import net.kyori.adventure.text.format.TextDecoration;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
 
 import static net.kyori.adventure.text.Component.text;
 import static net.kyori.adventure.text.format.Style.style;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 
 public class MiniMessageSerializerTest extends AbstractTest {
   @Test
@@ -76,5 +81,41 @@ public class MiniMessageSerializerTest extends AbstractTest {
     final Component component = text("<<aqua> a");
     this.assertSerializedEquals(expected, component);
     this.assertParsedEquals(component, expected);
+  }
+
+  @ParameterizedTest
+  @ValueSource(strings = {"ABCDEF", "BedWars"})
+  void testRoundTripAfterTextReplacement(final String content) {
+    final String input = "<white>[<gradient:#e83920:#ffe5dd>" + content + "<white>]";
+    final MiniMessage miniMessage = MiniMessage.miniMessage();
+    final Component expected = miniMessage.deserialize(input)
+      .replaceText(TextReplacementConfig.builder()
+        .match(Pattern.quote("["))
+        .replacement(Component.empty())
+        .build())
+      .replaceText(TextReplacementConfig.builder()
+        .match(Pattern.quote("]"))
+        .replacement(Component.empty())
+        .build());
+    final String serialized = miniMessage.serialize(expected);
+    final Component actual = miniMessage.deserialize(serialized);
+
+    assertFalse(serialized.contains("]"));
+    assertEquals(ANSI.serialize(expected), ANSI.serialize(actual));
+  }
+
+  @ParameterizedTest
+  @ValueSource(strings = {
+    "<white>prefix <gradient:red:blue>text<white> suffix",
+    "<yellow>[<gradient:#ff0000:#00ff00>test<yellow>]",
+    "<white><gradient:red:blue>test<green>next",
+    "<white><gradient:red:blue>one<white> <gradient:green:yellow>two<white>"
+  })
+  void testRoundTripGradientStyles(final String input) {
+    final MiniMessage miniMessage = MiniMessage.miniMessage();
+    final Component expected = miniMessage.deserialize(input);
+    final Component actual = miniMessage.deserialize(miniMessage.serialize(expected));
+
+    assertEquals(ANSI.serialize(expected), ANSI.serialize(actual));
   }
 }


### PR DESCRIPTION
# Proposed PR

## Title

fix(minimessage): preserve transformed component children when serializing gradients

## Body

Fixes #1383

MiniMessage gradient and rainbow virtual components retain a serializer substitute for their canonical parsed form. After a component transformation such as `replaceText`, the virtual component can have new children while the renderer still points at the old substitute, causing removed text to reappear during serialization.

The serializer claim is now retained for the parsed virtual component, including nested canonical substitutes, and declined for later-transformed virtual instances so their current children are serialized. Adds regression coverage for the reported case and related gradient/style round trips.

Tested with `./gradlew :adventure-text-minimessage:check` and `./gradlew check`.
