### PR TITLE
feature(minimessage): Add tag resolver type hints

### DIFF
--- a/text-minimessage/src/main/java/net/kyori/adventure/text/minimessage/MiniMessageParser.java
+++ b/text-minimessage/src/main/java/net/kyori/adventure/text/minimessage/MiniMessageParser.java
@@ -40,8 +40,10 @@ import net.kyori.adventure.text.minimessage.internal.parser.node.TagNode;
 import net.kyori.adventure.text.minimessage.internal.parser.node.ValueNode;
 import net.kyori.adventure.text.minimessage.tag.Inserting;
 import net.kyori.adventure.text.minimessage.tag.Modifying;
+import net.kyori.adventure.text.minimessage.tag.PreProcess;
 import net.kyori.adventure.text.minimessage.tag.Tag;
 import net.kyori.adventure.text.minimessage.tag.resolver.TagResolver;
+import org.jspecify.annotations.Nullable;
 
 record MiniMessageParser(TagResolver tagResolver) {
 
@@ -172,8 +174,12 @@ record MiniMessageParser(TagResolver tagResolver) {
       final String sanitized = TokenParser.TagProvider.sanitizePlaceholderName(name);
       return combinedResolver.has(sanitized);
     };
+    final Predicate<String> preProcessTagChecker = name -> {
+      final @Nullable Class<? extends Tag> type = combinedResolver.tagType(name);
+      return type == null || type == Tag.class || PreProcess.class.isAssignableFrom(type);
+    };
 
-    final String preProcessed = TokenParser.resolvePreProcessTags(processedMessage, transformationFactory);
+    final String preProcessed = TokenParser.resolvePreProcessTags(processedMessage, transformationFactory, preProcessTagChecker);
     context.message(preProcessed);
     // Then, once MiniMessage placeholders have been inserted, we can do the real parse
     final RootNode root = TokenParser.parse(transformationFactory, tagNameChecker, preProcessed, processedMessage, context.strict());

--- a/text-minimessage/src/main/java/net/kyori/adventure/text/minimessage/internal/parser/TokenParser.java
+++ b/text-minimessage/src/main/java/net/kyori/adventure/text/minimessage/internal/parser/TokenParser.java
@@ -100,13 +100,30 @@ public final class TokenParser {
    * @since 4.10.0
    */
   public static String resolvePreProcessTags(final String message, final TagProvider provider) {
+    return resolvePreProcessTags(message, provider, name -> true);
+  }
+
+  /**
+   * Resolves all pre-process tags in a string.
+   *
+   * @param message the message
+   * @param provider the tag resolver, to gather preprocess tags
+   * @param preProcessTagChecker checks whether a tag may be a preprocess tag
+   * @return the resulting string
+   * @since 5.2.1
+   */
+  public static String resolvePreProcessTags(
+    final String message,
+    final TagProvider provider,
+    final Predicate<String> preProcessTagChecker
+  ) {
     int passes = 0;
     String lastResult;
     String result = message;
 
     do {
       lastResult = result;
-      final StringResolvingMatchedTokenConsumer stringTokenResolver = new StringResolvingMatchedTokenConsumer(lastResult, provider);
+      final StringResolvingMatchedTokenConsumer stringTokenResolver = new StringResolvingMatchedTokenConsumer(lastResult, provider, preProcessTagChecker);
 
       parseString(lastResult, false, stringTokenResolver);
       result = stringTokenResolver.result();

--- a/text-minimessage/src/main/java/net/kyori/adventure/text/minimessage/internal/parser/match/StringResolvingMatchedTokenConsumer.java
+++ b/text-minimessage/src/main/java/net/kyori/adventure/text/minimessage/internal/parser/match/StringResolvingMatchedTokenConsumer.java
@@ -26,6 +26,7 @@ package net.kyori.adventure.text.minimessage.internal.parser.match;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Objects;
+import java.util.function.Predicate;
 import net.kyori.adventure.text.minimessage.internal.TagInternals;
 import net.kyori.adventure.text.minimessage.internal.parser.Token;
 import net.kyori.adventure.text.minimessage.internal.parser.TokenParser;
@@ -46,6 +47,7 @@ import static net.kyori.adventure.text.minimessage.internal.parser.TokenParser.t
 public final class StringResolvingMatchedTokenConsumer extends MatchedTokenConsumer<String> {
   private final StringBuilder builder;
   private final TagProvider tagProvider;
+  private final Predicate<String> preProcessTagChecker;
 
   /**
    * Creates a string resolving matched token consumer.
@@ -58,9 +60,26 @@ public final class StringResolvingMatchedTokenConsumer extends MatchedTokenConsu
     final String input,
     final TagProvider tagProvider
   ) {
+    this(input, tagProvider, name -> true);
+  }
+
+  /**
+   * Creates a string resolving matched token consumer.
+   *
+   * @param input the input
+   * @param tagProvider the resolver for argument-less tags
+   * @param preProcessTagChecker checks whether a tag may be a preprocess tag
+   * @since 5.2.1
+   */
+  public StringResolvingMatchedTokenConsumer(
+    final String input,
+    final TagProvider tagProvider,
+    final Predicate<String> preProcessTagChecker
+  ) {
     super(input);
     this.builder = new StringBuilder(input.length());
     this.tagProvider = tagProvider;
+    this.preProcessTagChecker = preProcessTagChecker;
   }
 
   @Override
@@ -79,7 +98,7 @@ public final class StringResolvingMatchedTokenConsumer extends MatchedTokenConsu
       final String tag = index == -1 ? cleanup : cleanup.substring(0, index);
 
       // we might care if it's a valid tag!
-      if (TagInternals.sanitizeAndCheckValidTagName(tag)) {
+      if (TagInternals.sanitizeAndCheckValidTagName(tag) && this.preProcessTagChecker.test(TokenParser.TagProvider.sanitizePlaceholderName(tag))) {
         final List<Token> tokens = tokenize(match, false);
         final List<TagPart> parts = new ArrayList<>();
         final List<Token> childs = tokens.isEmpty() ? null : tokens.getFirst().childTokens();

--- a/text-minimessage/src/main/java/net/kyori/adventure/text/minimessage/tag/resolver/CachingTagResolver.java
+++ b/text-minimessage/src/main/java/net/kyori/adventure/text/minimessage/tag/resolver/CachingTagResolver.java
@@ -64,6 +64,11 @@ final class CachingTagResolver implements TagResolver.WithoutArguments, Mappable
   }
 
   @Override
+  public @Nullable Class<? extends Tag> tagType(final String name) {
+    return this.resolver.tagType(name);
+  }
+
+  @Override
   public boolean contributeToMap(final Map<String, Tag> map) {
     if (this.resolver instanceof MappableResolver mappableResolver) {
       return mappableResolver.contributeToMap(map);

--- a/text-minimessage/src/main/java/net/kyori/adventure/text/minimessage/tag/resolver/MapTagResolver.java
+++ b/text-minimessage/src/main/java/net/kyori/adventure/text/minimessage/tag/resolver/MapTagResolver.java
@@ -41,6 +41,12 @@ record MapTagResolver(Map<String, ? extends Tag> tagMap) implements TagResolver.
   }
 
   @Override
+  public Class<? extends Tag> tagType(final String name) {
+    final Tag tag = this.tagMap.get(name);
+    return tag == null ? null : tag.getClass();
+  }
+
+  @Override
   public boolean contributeToMap(final Map<String, Tag> map) {
     map.putAll(this.tagMap);
     return true;

--- a/text-minimessage/src/main/java/net/kyori/adventure/text/minimessage/tag/resolver/SequentialTagResolver.java
+++ b/text-minimessage/src/main/java/net/kyori/adventure/text/minimessage/tag/resolver/SequentialTagResolver.java
@@ -82,10 +82,18 @@ record SequentialTagResolver(TagResolver[] resolvers) implements TagResolver, Se
 
   @Override
   public @Nullable Class<? extends Tag> tagType(final String name) {
+    Class<? extends Tag> combinedType = null;
     for (final TagResolver resolver : this.resolvers) {
       final @Nullable Class<? extends Tag> type = resolver.tagType(name);
       if (type != null) {
-        return type;
+        if (combinedType != null && combinedType != type) {
+          return Tag.class;
+        }
+        combinedType = type;
+        if (resolver instanceof SingleResolver || resolver instanceof MapTagResolver) {
+          return combinedType;
+        }
+        continue;
       }
 
       if (resolver instanceof SingleResolver || resolver instanceof MapTagResolver) {
@@ -96,7 +104,7 @@ record SequentialTagResolver(TagResolver[] resolvers) implements TagResolver, Se
         return null;
       }
     }
-    return null;
+    return combinedType;
   }
 
   @Override

--- a/text-minimessage/src/main/java/net/kyori/adventure/text/minimessage/tag/resolver/SequentialTagResolver.java
+++ b/text-minimessage/src/main/java/net/kyori/adventure/text/minimessage/tag/resolver/SequentialTagResolver.java
@@ -81,6 +81,25 @@ record SequentialTagResolver(TagResolver[] resolvers) implements TagResolver, Se
   }
 
   @Override
+  public @Nullable Class<? extends Tag> tagType(final String name) {
+    for (final TagResolver resolver : this.resolvers) {
+      final @Nullable Class<? extends Tag> type = resolver.tagType(name);
+      if (type != null) {
+        return type;
+      }
+
+      if (resolver instanceof SingleResolver || resolver instanceof MapTagResolver) {
+        if (resolver.has(name)) {
+          return null;
+        }
+      } else if (resolver instanceof TagResolver.WithoutArguments || resolver.has(name)) {
+        return null;
+      }
+    }
+    return null;
+  }
+
+  @Override
   public void handle(final Component serializable, final ClaimConsumer consumer) {
     for (final TagResolver resolver : this.resolvers) {
       if (resolver instanceof SerializableResolver serializableResolver) {

--- a/text-minimessage/src/main/java/net/kyori/adventure/text/minimessage/tag/resolver/SingleResolver.java
+++ b/text-minimessage/src/main/java/net/kyori/adventure/text/minimessage/tag/resolver/SingleResolver.java
@@ -33,6 +33,11 @@ record SingleResolver(String key, Tag tag) implements TagResolver.Single, Mappab
   }
 
   @Override
+  public Class<? extends Tag> tagType(final String name) {
+    return this.has(name) ? this.tag.getClass() : null;
+  }
+
+  @Override
   public boolean contributeToMap(final Map<String, Tag> map) {
     map.put(this.key, this.tag);
     return true;

--- a/text-minimessage/src/main/java/net/kyori/adventure/text/minimessage/tag/resolver/TagResolver.java
+++ b/text-minimessage/src/main/java/net/kyori/adventure/text/minimessage/tag/resolver/TagResolver.java
@@ -222,6 +222,21 @@ public interface TagResolver {
   @Nullable Tag resolve(@TagPattern final String name, final ArgumentQueue arguments, final Context ctx) throws ParsingException;
 
   /**
+   * Get the type of tag this resolver handles with a certain name.
+   *
+   * <p>This method may be used to avoid resolving tags during pre-processing when the returned type is known not
+   * to be a {@link net.kyori.adventure.text.minimessage.tag.PreProcess} tag. Returning {@code null} indicates that
+   * the type is unknown, and causes the tag to be resolved as usual.</p>
+   *
+   * @param name the tag name
+   * @return the tag type, or {@code null} if unknown
+   * @since 5.2.1
+   */
+  default @Nullable Class<? extends Tag> tagType(@TagPattern final String name) {
+    return null;
+  }
+
+  /**
    * Get whether this resolver handles tags with a certain name.
    *
    * <p>This does not allow validating arguments.</p>

--- a/text-minimessage/src/test/java/net/kyori/adventure/text/minimessage/tag/PreProcessTagTest.java
+++ b/text-minimessage/src/test/java/net/kyori/adventure/text/minimessage/tag/PreProcessTagTest.java
@@ -23,13 +23,17 @@
  */
 package net.kyori.adventure.text.minimessage.tag;
 
+import java.util.concurrent.atomic.AtomicInteger;
 import net.kyori.adventure.text.Component;
 import net.kyori.adventure.text.minimessage.AbstractTest;
+import net.kyori.adventure.text.minimessage.Context;
+import net.kyori.adventure.text.minimessage.tag.resolver.ArgumentQueue;
 import net.kyori.adventure.text.minimessage.tag.resolver.TagResolver;
 import org.junit.jupiter.api.Test;
 
 import static net.kyori.adventure.text.Component.text;
 import static net.kyori.adventure.text.minimessage.tag.resolver.Placeholder.parsed;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 public class PreProcessTagTest extends AbstractTest {
 
@@ -69,5 +73,75 @@ public class PreProcessTagTest extends AbstractTest {
       input,
       parsed("recursion", "<recursion>")
     );
+  }
+
+  @Test
+  void resolverWithoutTypeHintRemainsCompatible() {
+    final AtomicInteger calls = new AtomicInteger();
+    final TagResolver resolver = new TagResolver() {
+      @Override
+      public Tag resolve(final String name, final ArgumentQueue arguments, final Context ctx) {
+        calls.incrementAndGet();
+        return "probe".equals(name) ? Tag.selfClosingInserting(text("value")) : null;
+      }
+
+      @Override
+      public boolean has(final String name) {
+        return "probe".equals(name);
+      }
+    };
+
+    assertParsedEquals(text("value"), "<probe>", resolver);
+    assertEquals(2, calls.get());
+  }
+
+  @Test
+  void resolverTypeHintAvoidsUnnecessaryResolution() {
+    final AtomicInteger calls = new AtomicInteger();
+    final TagResolver resolver = new TagResolver() {
+      @Override
+      public Tag resolve(final String name, final ArgumentQueue arguments, final Context ctx) {
+        calls.incrementAndGet();
+        return "probe".equals(name) ? Tag.selfClosingInserting(text("value")) : null;
+      }
+
+      @Override
+      public Class<? extends Tag> tagType(final String name) {
+        return "probe".equals(name) ? Inserting.class : null;
+      }
+
+      @Override
+      public boolean has(final String name) {
+        return "probe".equals(name);
+      }
+    };
+
+    assertParsedEquals(text("value"), "<probe>", resolver);
+    assertEquals(1, calls.get());
+  }
+
+  @Test
+  void preprocessTypeHintStillResolves() {
+    final AtomicInteger calls = new AtomicInteger();
+    final TagResolver resolver = new TagResolver() {
+      @Override
+      public Tag resolve(final String name, final ArgumentQueue arguments, final Context ctx) {
+        calls.incrementAndGet();
+        return "probe".equals(name) ? Tag.preProcessParsed("value") : null;
+      }
+
+      @Override
+      public Class<? extends Tag> tagType(final String name) {
+        return "probe".equals(name) ? PreProcess.class : null;
+      }
+
+      @Override
+      public boolean has(final String name) {
+        return "probe".equals(name);
+      }
+    };
+
+    assertParsedEquals(text("value"), "<probe>", resolver);
+    assertEquals(1, calls.get());
   }
 }

--- a/text-minimessage/src/test/java/net/kyori/adventure/text/minimessage/tag/PreProcessTagTest.java
+++ b/text-minimessage/src/test/java/net/kyori/adventure/text/minimessage/tag/PreProcessTagTest.java
@@ -30,6 +30,8 @@ import net.kyori.adventure.text.minimessage.Context;
 import net.kyori.adventure.text.minimessage.tag.resolver.ArgumentQueue;
 import net.kyori.adventure.text.minimessage.tag.resolver.TagResolver;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
 
 import static net.kyori.adventure.text.Component.text;
 import static net.kyori.adventure.text.minimessage.tag.resolver.Placeholder.parsed;
@@ -118,6 +120,32 @@ public class PreProcessTagTest extends AbstractTest {
 
     assertParsedEquals(text("value"), "<probe>", resolver);
     assertEquals(1, calls.get());
+  }
+
+  @ParameterizedTest
+  @ValueSource(booleans = {false, true})
+  void preprocessFallbackIsNotSkippedByAnEarlierTypeHint(final boolean throwsException) {
+    final TagResolver resolver = new TagResolver() {
+      @Override
+      public Tag resolve(final String name, final ArgumentQueue arguments, final Context ctx) {
+        if (throwsException) {
+          throw ctx.newException("Try the next resolver");
+        }
+        return null;
+      }
+
+      @Override
+      public Class<? extends Tag> tagType(final String name) {
+        return "probe".equals(name) ? Inserting.class : null;
+      }
+
+      @Override
+      public boolean has(final String name) {
+        return "probe".equals(name);
+      }
+    };
+
+    assertParsedEquals(text("value"), "<probe>", TagResolver.resolver(parsed("probe", "value"), resolver));
   }
 
   @Test


### PR DESCRIPTION
Fixes #1424

## Summary

MiniMessage currently resolves ordinary tags during both the preprocessing and normal parsing passes. This adds an additive `TagResolver#tagType(String)` hint so resolvers can identify known non-`PreProcess` tags and avoid the unnecessary preprocessing resolution.

Existing resolvers that do not provide the hint retain the previous behavior. Built-in single-tag, mapped, cached, and composed resolvers propagate available type information.

## Testing

- Added resolver call-count regression tests.
- Verified legacy resolvers remain at two calls.
- Verified hinted ordinary tags resolve once.
- Verified hinted `PreProcess` tags still resolve during preprocessing.
- `./gradlew :adventure-text-minimessage:check --rerun`
- `./gradlew check --rerun`



Found and fixed a real fallback bug in composed tag hints. Added null-return and exception regression tests. Full check passes. Changes are in [SequentialTagResolver.java](https://github.com/flennium/adventure/blob/agent/1424-tag-resolver-type-hints/text-minimessage/src/main/java/net/kyori/adventure/text/minimessage/tag/resolver/SequentialTagResolver.java) and [PreProcessTagTest.java](https://github.com/flennium/adventure/blob/agent/1424-tag-resolver-type-hints/text-minimessage/src/test/java/net/kyori/adventure/text/minimessage/tag/PreProcessTagTest.java).
