### PR TITLE
perf(api,nbt): Avoid copying collections twice

### DIFF
--- a/api/src/main/java/net/kyori/adventure/util/InheritanceAwareMapImpl.java
+++ b/api/src/main/java/net/kyori/adventure/util/InheritanceAwareMapImpl.java
@@ -95,7 +95,7 @@ final class InheritanceAwareMapImpl<C, V> implements InheritanceAwareMap<C, V> {
 
     @Override
     public InheritanceAwareMap<C, V> build() {
-      return new InheritanceAwareMapImpl<>(this.strict, Map.copyOf(new LinkedHashMap<>(this.values)));
+      return new InheritanceAwareMapImpl<>(this.strict, Map.copyOf(this.values));
     }
 
     @Override

--- a/nbt/src/main/java/net/kyori/adventure/nbt/BinaryTagTypes.java
+++ b/nbt/src/main/java/net/kyori/adventure/nbt/BinaryTagTypes.java
@@ -140,7 +140,7 @@ public final class BinaryTagTypes {
         final BinaryTag tag = type.read(input);
         tags.put(key, tag);
       }
-      return CompoundBinaryTagImpl.create(tags);
+      return CompoundBinaryTag.from(tags);
     }
   }, (tag, output) -> {
     for (final Map.Entry<String, ? extends BinaryTag> entry : tag) {

--- a/nbt/src/main/java/net/kyori/adventure/nbt/CompoundBinaryTag.java
+++ b/nbt/src/main/java/net/kyori/adventure/nbt/CompoundBinaryTag.java
@@ -23,7 +23,6 @@
  */
 package net.kyori.adventure.nbt;
 
-import java.util.HashMap;
 import java.util.Map;
 import java.util.Set;
 import java.util.function.Function;
@@ -62,7 +61,7 @@ public sealed interface CompoundBinaryTag extends BinaryTag, CompoundTagSetter<C
    */
   static CompoundBinaryTag from(final Map<String, ? extends BinaryTag> tags) {
     if (tags.isEmpty()) return empty();
-    return new CompoundBinaryTagImpl(new HashMap<>(tags)); // explicitly copy
+    return new CompoundBinaryTagImpl(tags);
   }
 
   /**

--- a/nbt/src/main/java/net/kyori/adventure/nbt/CompoundBinaryTagImpl.java
+++ b/nbt/src/main/java/net/kyori/adventure/nbt/CompoundBinaryTagImpl.java
@@ -35,13 +35,13 @@ import org.jspecify.annotations.Nullable;
 import static java.util.Objects.requireNonNull;
 
 @Debug.Renderer(text = "\"CompoundBinaryTag[length=\" + this.tags.size() + \"]\"", childrenArray = "this.tags.entrySet().toArray()", hasChildren = "!this.tags.isEmpty()")
-record CompoundBinaryTagImpl(Map<String, BinaryTag> tags) implements CompoundBinaryTag {
-
-  static CompoundBinaryTag create(final Map<String, BinaryTag> tags) {
-    return new CompoundBinaryTagImpl(Map.copyOf(tags));
-  }
+record CompoundBinaryTagImpl(Map<String, ? extends BinaryTag> tags) implements CompoundBinaryTag {
 
   static final CompoundBinaryTag EMPTY = new CompoundBinaryTagImpl(Map.of());
+
+  CompoundBinaryTagImpl {
+    tags = Map.copyOf(tags);
+  }
 
   @Override
   public boolean contains(final String key) {
@@ -81,11 +81,7 @@ record CompoundBinaryTagImpl(Map<String, BinaryTag> tags) implements CompoundBin
 
   @Override
   public CompoundBinaryTag put(final CompoundBinaryTag tag) {
-    return this.edit(map -> {
-      for (final String key : tag.keySet()) {
-        map.put(key, tag.get(key));
-      }
-    });
+    return this.put(((CompoundBinaryTagImpl) tag).tags());
   }
 
   @Override
@@ -246,7 +242,7 @@ record CompoundBinaryTagImpl(Map<String, BinaryTag> tags) implements CompoundBin
   private CompoundBinaryTag edit(final Consumer<Map<String, BinaryTag>> consumer) {
     final Map<String, BinaryTag> tags = new HashMap<>(this.tags);
     consumer.accept(tags);
-    return new CompoundBinaryTagImpl(new HashMap<>(tags)); // explicitly copy
+    return new CompoundBinaryTagImpl(tags);
   }
 
   @Override

--- a/nbt/src/main/java/net/kyori/adventure/nbt/CompoundTagBuilder.java
+++ b/nbt/src/main/java/net/kyori/adventure/nbt/CompoundTagBuilder.java
@@ -62,11 +62,7 @@ final class CompoundTagBuilder implements CompoundBinaryTag.Builder {
 
   @Override
   public CompoundBinaryTag.Builder put(final CompoundBinaryTag tag) {
-    final Map<String, BinaryTag> tags = this.tags();
-    for (final String key : tag.keySet()) {
-      tags.put(key, tag.get(key));
-    }
-    return this;
+    return this.put(((CompoundBinaryTagImpl) tag).tags());
   }
 
   @Override
@@ -89,6 +85,6 @@ final class CompoundTagBuilder implements CompoundBinaryTag.Builder {
   @Override
   public CompoundBinaryTag build() {
     if (this.tags == null) return CompoundBinaryTag.empty();
-    return new CompoundBinaryTagImpl(new HashMap<>(this.tags)); // explicitly copy
+    return CompoundBinaryTag.from(this.tags);
   }
 }

--- a/nbt/src/main/java/net/kyori/adventure/nbt/ListBinaryTag.java
+++ b/nbt/src/main/java/net/kyori/adventure/nbt/ListBinaryTag.java
@@ -23,7 +23,6 @@
  */
 package net.kyori.adventure.nbt;
 
-import java.util.ArrayList;
 import java.util.List;
 import java.util.function.Consumer;
 import java.util.stream.Collector;
@@ -148,7 +147,7 @@ public sealed interface ListBinaryTag extends ListTagSetter<ListBinaryTag, Binar
     if (tags.isEmpty()) return empty();
     if (type == BinaryTagTypes.END) throw new IllegalArgumentException("Cannot create a list of " + BinaryTagTypes.END);
     ListBinaryTagImpl.validateTagType(tags, type == BinaryTagTypes.LIST_WILDCARD);
-    return new ListBinaryTagImpl(type, type == BinaryTagTypes.LIST_WILDCARD, new ArrayList<>(tags)); // explicitly copy
+    return new ListBinaryTagImpl(type, type == BinaryTagTypes.LIST_WILDCARD, tags);
   }
 
   /**

--- a/nbt/src/main/java/net/kyori/adventure/nbt/ListBinaryTagImpl.java
+++ b/nbt/src/main/java/net/kyori/adventure/nbt/ListBinaryTagImpl.java
@@ -148,7 +148,7 @@ record ListBinaryTagImpl(BinaryTagType<? extends BinaryTag> elementType, boolean
     if (maybeElementType != null) {
       elementType = maybeElementType;
     }
-    return new ListBinaryTagImpl(elementType, this.permitsHeterogeneity, new ArrayList<>(tags)); // explicitly copy
+    return new ListBinaryTagImpl(elementType, this.permitsHeterogeneity, tags);
   }
 
   @Override

--- a/nbt/src/main/java/net/kyori/adventure/nbt/ListTagBuilder.java
+++ b/nbt/src/main/java/net/kyori/adventure/nbt/ListTagBuilder.java
@@ -80,6 +80,6 @@ final class ListTagBuilder<T extends BinaryTag> implements ListBinaryTag.Builder
   @Override
   public ListBinaryTag build() {
     if (this.tags == null) return ListBinaryTag.empty();
-    return new ListBinaryTagImpl(this.elementType, this.permitsHeterogeneity, new ArrayList<>(this.tags)); // explicitly copy
+    return new ListBinaryTagImpl(this.elementType, this.permitsHeterogeneity, this.tags);
   }
 }


### PR DESCRIPTION
Several call sites copied a list or map immediately before handing it to a constructor that copies again, or copied a local that was already a fresh copy.

Give CompoundBinaryTagImpl a canonical constructor that copies, so its callers no longer have to hand it a map they own, and let both put(CompoundBinaryTag) overloads use putAll rather than copying the key set and looking every value up again.