### PR TITLE
refactor(api,nbt): Use compact canonical record constructors

### DIFF
--- a/api/src/main/java/net/kyori/adventure/nbt/api/BinaryTagHolderImpl.java
+++ b/api/src/main/java/net/kyori/adventure/nbt/api/BinaryTagHolderImpl.java
@@ -28,8 +28,8 @@ import net.kyori.adventure.util.Codec;
 import static java.util.Objects.requireNonNull;
 
 record BinaryTagHolderImpl(String string) implements BinaryTagHolder {
-  BinaryTagHolderImpl(final String string) {
-    this.string = requireNonNull(string, "string");
+  BinaryTagHolderImpl {
+    requireNonNull(string, "string");
   }
 
   @Override

--- a/api/src/main/java/net/kyori/adventure/resource/ResourcePackInfoImpl.java
+++ b/api/src/main/java/net/kyori/adventure/resource/ResourcePackInfoImpl.java
@@ -41,10 +41,10 @@ import org.jspecify.annotations.Nullable;
 import static java.util.Objects.requireNonNull;
 
 record ResourcePackInfoImpl(UUID id, URI uri, String hash) implements ResourcePackInfo {
-  ResourcePackInfoImpl(final UUID id, final URI uri, final String hash) {
-    this.id = requireNonNull(id, "id");
-    this.uri = requireNonNull(uri, "uri");
-    this.hash = requireNonNull(hash, "hash");
+  ResourcePackInfoImpl {
+    requireNonNull(id, "id");
+    requireNonNull(uri, "uri");
+    requireNonNull(hash, "hash");
   }
 
   static final class BuilderImpl implements Builder {

--- a/api/src/main/java/net/kyori/adventure/text/BlockNBTComponentImpl.java
+++ b/api/src/main/java/net/kyori/adventure/text/BlockNBTComponentImpl.java
@@ -136,10 +136,10 @@ record BlockNBTComponentImpl(
   }
 
   record WorldPosImpl(Coordinate x, Coordinate y, Coordinate z) implements WorldPos {
-    WorldPosImpl(final Coordinate x, final Coordinate y, final Coordinate z) {
-      this.x = requireNonNull(x, "x");
-      this.y = requireNonNull(y, "y");
-      this.z = requireNonNull(z, "z");
+    WorldPosImpl {
+      requireNonNull(x, "x");
+      requireNonNull(y, "y");
+      requireNonNull(z, "z");
     }
 
     @Override
@@ -153,9 +153,8 @@ record BlockNBTComponentImpl(
     }
 
     record CoordinateImpl(int value, Type type) implements Coordinate {
-      CoordinateImpl(final int value, final Type type) {
-        this.value = value;
-        this.type = requireNonNull(type, "type");
+      CoordinateImpl {
+        requireNonNull(type, "type");
       }
 
       @Override

--- a/api/src/main/java/net/kyori/adventure/text/format/TextDecorationAndStateImpl.java
+++ b/api/src/main/java/net/kyori/adventure/text/format/TextDecorationAndStateImpl.java
@@ -26,10 +26,9 @@ package net.kyori.adventure.text.format;
 import static java.util.Objects.requireNonNull;
 
 record TextDecorationAndStateImpl(TextDecoration decoration, TextDecoration.State state) implements TextDecorationAndState {
-  TextDecorationAndStateImpl(final TextDecoration decoration, final TextDecoration.State state) {
+  TextDecorationAndStateImpl {
     // no null check is required on the decoration since this constructor is always invoked in such a way that
     // decoration is always non-null
-    this.decoration = decoration;
-    this.state = requireNonNull(state, "state");
+    requireNonNull(state, "state");
   }
 }

--- a/api/src/main/java/net/kyori/adventure/title/TitleImpl.java
+++ b/api/src/main/java/net/kyori/adventure/title/TitleImpl.java
@@ -31,10 +31,9 @@ import org.jspecify.annotations.Nullable;
 import static java.util.Objects.requireNonNull;
 
 record TitleImpl(Component title, Component subtitle, @Nullable Times times) implements Title {
-  TitleImpl(final Component title, final Component subtitle, final @Nullable Times times) {
-    this.title = requireNonNull(title, "title");
-    this.subtitle = requireNonNull(subtitle, "subtitle");
-    this.times = times;
+  TitleImpl {
+    requireNonNull(title, "title");
+    requireNonNull(subtitle, "subtitle");
   }
 
   @Override
@@ -53,10 +52,10 @@ record TitleImpl(Component title, Component subtitle, @Nullable Times times) imp
   }
 
   record TimesImpl(Duration fadeIn, Duration stay, Duration fadeOut) implements Times {
-    TimesImpl(final Duration fadeIn, final Duration stay, final Duration fadeOut) {
-      this.fadeIn = requireNonNull(fadeIn, "fadeIn");
-      this.stay = requireNonNull(stay, "stay");
-      this.fadeOut = requireNonNull(fadeOut, "fadeOut");
+    TimesImpl {
+      requireNonNull(fadeIn, "fadeIn");
+      requireNonNull(stay, "stay");
+      requireNonNull(fadeOut, "fadeOut");
     }
   }
 }

--- a/nbt/src/main/java/net/kyori/adventure/nbt/ByteArrayBinaryTagImpl.java
+++ b/nbt/src/main/java/net/kyori/adventure/nbt/ByteArrayBinaryTagImpl.java
@@ -31,8 +31,8 @@ import org.jetbrains.annotations.Debug;
 @SuppressWarnings("ArrayRecordComponent") // We override equals/hashCode/toString.
 @Debug.Renderer(text = "\"byte[\" + this.value.length + \"]\"", childrenArray = "this.value", hasChildren = "this.value.length > 0")
 record ByteArrayBinaryTagImpl(byte[] value) implements ByteArrayBinaryTag {
-  ByteArrayBinaryTagImpl(final byte[] value) {
-    this.value = Arrays.copyOf(value, value.length);
+  ByteArrayBinaryTagImpl {
+    value = Arrays.copyOf(value, value.length);
   }
 
   @Override

--- a/nbt/src/main/java/net/kyori/adventure/nbt/IntArrayBinaryTagImpl.java
+++ b/nbt/src/main/java/net/kyori/adventure/nbt/IntArrayBinaryTagImpl.java
@@ -36,8 +36,8 @@ import org.jetbrains.annotations.Debug;
 @Debug.Renderer(text = "\"int[\" + this.value.length + \"]\"", childrenArray = "this.value", hasChildren = "this.value.length > 0")
 record IntArrayBinaryTagImpl(int... value) implements IntArrayBinaryTag {
 
-  IntArrayBinaryTagImpl(final int... value) {
-    this.value = Arrays.copyOf(value, value.length);
+  IntArrayBinaryTagImpl {
+    value = Arrays.copyOf(value, value.length);
   }
 
   @Override

--- a/nbt/src/main/java/net/kyori/adventure/nbt/ListBinaryTagImpl.java
+++ b/nbt/src/main/java/net/kyori/adventure/nbt/ListBinaryTagImpl.java
@@ -41,10 +41,8 @@ import org.jspecify.annotations.Nullable;
 record ListBinaryTagImpl(BinaryTagType<? extends BinaryTag> elementType, boolean permitsHeterogeneity, List<BinaryTag> tags) implements ListBinaryTag {
   static final ListBinaryTag EMPTY = new ListBinaryTagImpl(BinaryTagTypes.END, false, List.of());
 
-  ListBinaryTagImpl(final BinaryTagType<? extends BinaryTag> elementType, final boolean permitsHeterogeneity, final List<BinaryTag> tags) {
-    this.tags = List.copyOf(tags);
-    this.permitsHeterogeneity = permitsHeterogeneity;
-    this.elementType = elementType;
+  ListBinaryTagImpl {
+    tags = List.copyOf(tags);
   }
 
   @Override

--- a/nbt/src/main/java/net/kyori/adventure/nbt/LongArrayBinaryTagImpl.java
+++ b/nbt/src/main/java/net/kyori/adventure/nbt/LongArrayBinaryTagImpl.java
@@ -36,8 +36,8 @@ import org.jetbrains.annotations.Debug;
 @Debug.Renderer(text = "\"long[\" + this.value.length + \"]\"", childrenArray = "this.value", hasChildren = "this.value.length > 0")
 record LongArrayBinaryTagImpl(long[] value) implements LongArrayBinaryTag {
 
-  LongArrayBinaryTagImpl(final long[] value) {
-    this.value = Arrays.copyOf(value, value.length);
+  LongArrayBinaryTagImpl {
+    value = Arrays.copyOf(value, value.length);
   }
 
   @Override


### PR DESCRIPTION
Replace the longhand canonical constructors with compact ones, matching `HSVLikeImpl` and `PlayerHeadObjectContentsImpl`. Behaviour is unchanged.