### PR TITLE
perf(nbt): Add a collection fast path to ListBinaryTag#add

### DIFF
--- a/nbt/src/main/java/net/kyori/adventure/nbt/ListBinaryTagImpl.java
+++ b/nbt/src/main/java/net/kyori/adventure/nbt/ListBinaryTagImpl.java
@@ -91,8 +91,10 @@ record ListBinaryTagImpl(BinaryTagType<? extends BinaryTag> elementType, boolean
 
   @Override
   public ListBinaryTag add(final Iterable<? extends BinaryTag> tagsToAdd) {
-    if (tagsToAdd instanceof Collection<?> && ((Collection<?>) tagsToAdd).isEmpty()) {
-      return this;
+    if (tagsToAdd instanceof final Collection<? extends BinaryTag> collection) {
+      if (collection.isEmpty()) return this;
+      final BinaryTagType<?> type = ListBinaryTagImpl.validateTagType(collection, this.permitsHeterogeneity);
+      return this.edit(tags -> tags.addAll(collection), type);
     }
     final BinaryTagType<?> type = ListBinaryTagImpl.validateTagType(tagsToAdd, this.permitsHeterogeneity);
     return this.edit(tags -> {


### PR DESCRIPTION
Use the Collection with List#addAll rather than adding one element at a time, so the backing list can size itself once.

Probably would have just be better if add had a method to take a collection so its instanceof check would be no-op at runtime oh well.