### PR TITLE
fix(nbt): Align ListBinaryTag hashCode with equals

### DIFF
--- a/nbt/src/main/java/net/kyori/adventure/nbt/ListBinaryTagImpl.java
+++ b/nbt/src/main/java/net/kyori/adventure/nbt/ListBinaryTagImpl.java
@@ -237,6 +237,12 @@ record ListBinaryTagImpl(BinaryTagType<? extends BinaryTag> elementType, boolean
   public boolean equals(final Object that) {
     return this == that || (that instanceof final ListBinaryTagImpl lat && this.tags.equals(lat.tags));
   }
+
+  @Override
+  public int hashCode() {
+    // equality only considers the elements, so neither may the hash
+    return this.tags.hashCode();
+  }
 }
 
 final class ListBinaryTag0 {


### PR DESCRIPTION
`ListBinaryTagImpl` overrides equals to compare only the elements, but kept the record's generated `hashCode`, which also forced in `elementType` and `permitsHeterogeneity`. Equal lists could therefore hash differently and be missed by hash-based collections.