### PR TITLE
Fix: parse local- and relative coordinates without number suffix, allow parsing floating point relative coordinates

### DIFF
--- a/api/src/main/java/net/kyori/adventure/text/BlockNBTComponent.java
+++ b/api/src/main/java/net/kyori/adventure/text/BlockNBTComponent.java
@@ -214,18 +214,18 @@ public sealed interface BlockNBTComponent extends NBTComponent<BlockNBTComponent
       final Matcher localMatch = BlockNBTComponentImpl.Tokens.LOCAL_PATTERN.matcher(input);
       if (localMatch.matches()) {
         return BlockNBTComponent.LocalPos.localPos(
-          Double.parseDouble(localMatch.group(1)),
-          Double.parseDouble(localMatch.group(3)),
-          Double.parseDouble(localMatch.group(5))
+          BlockNBTComponentImpl.Tokens.parseOptionalDouble(localMatch.group(1)),
+          BlockNBTComponentImpl.Tokens.parseOptionalDouble(localMatch.group(4)),
+          BlockNBTComponentImpl.Tokens.parseOptionalDouble(localMatch.group(7))
         );
       }
 
       final Matcher worldMatch = BlockNBTComponentImpl.Tokens.WORLD_PATTERN.matcher(input);
       if (worldMatch.matches()) {
         return BlockNBTComponent.WorldPos.worldPos(
-          BlockNBTComponentImpl.Tokens.deserializeCoordinate(worldMatch.group(1), worldMatch.group(2)),
-          BlockNBTComponentImpl.Tokens.deserializeCoordinate(worldMatch.group(3), worldMatch.group(4)),
-          BlockNBTComponentImpl.Tokens.deserializeCoordinate(worldMatch.group(5), worldMatch.group(6))
+          BlockNBTComponentImpl.Tokens.deserializeCoordinate(worldMatch.group(1)),
+          BlockNBTComponentImpl.Tokens.deserializeCoordinate(worldMatch.group(7)),
+          BlockNBTComponentImpl.Tokens.deserializeCoordinate(worldMatch.group(13))
         );
       }
 

--- a/api/src/main/java/net/kyori/adventure/text/BlockNBTComponentImpl.java
+++ b/api/src/main/java/net/kyori/adventure/text/BlockNBTComponentImpl.java
@@ -166,33 +166,44 @@ record BlockNBTComponentImpl(
   }
 
   static final class Tokens {
-    static final Pattern LOCAL_PATTERN = Pattern.compile("^\\^(-?\\d+(\\.\\d+)?) \\^(-?\\d+(\\.\\d+)?) \\^(-?\\d+(\\.\\d+)?)$");
-    static final Pattern WORLD_PATTERN = Pattern.compile("^(~?)(-?\\d+) (~?)(-?\\d+) (~?)(-?\\d+)$");
+    static final Pattern LOCAL_PATTERN = Pattern.compile("^\\^(-?(\\d+)?(\\.\\d+)?)? \\^(-?(\\d+)?(\\.\\d+)?)? \\^(-?(\\d+)?(\\.\\d+)?)?$");
+    static final Pattern WORLD_PATTERN = Pattern.compile("^((-?\\d+)|(~(-?(\\d+)?(\\.\\d+)?)?)) ((-?\\d+)|(~(-?(\\d+)?(\\.\\d+)?)?)) ((-?\\d+)|(~(-?(\\d+)?(\\.\\d+)?)?))$");
 
     static final String LOCAL_SYMBOL = "^";
     static final String RELATIVE_SYMBOL = "~";
-    static final String ABSOLUTE_SYMBOL = "";
 
     private Tokens() {
     }
 
-    static WorldPos.Coordinate deserializeCoordinate(final String prefix, final String value) {
-      final int i = Integer.parseInt(value);
-      if (prefix.equals(ABSOLUTE_SYMBOL)) {
-        return WorldPos.Coordinate.absolute(i);
-      } else if (prefix.equals(RELATIVE_SYMBOL)) {
-        return WorldPos.Coordinate.relative(i);
-      } else {
-        throw new AssertionError(); // regex does not allow any other value for prefix.
+    static double parseOptionalDouble(final String value) {
+      if (value.isEmpty()) {
+        return 0.0d;
       }
+      return Double.parseDouble(value);
+    }
+
+    static WorldPos.Coordinate deserializeCoordinate(final String value) {
+      if (value.startsWith(RELATIVE_SYMBOL)) {
+        return WorldPos.Coordinate.relative((int) Math.floor(parseOptionalDouble(value.substring(1))));
+      }
+      return WorldPos.Coordinate.absolute(Integer.parseInt(value));
     }
 
     static String serializeLocal(final double value) {
+      if (value == 0.0d) {
+        return LOCAL_SYMBOL;
+      }
       return LOCAL_SYMBOL + value;
     }
 
     static String serializeCoordinate(final WorldPos.Coordinate coordinate) {
-      return (coordinate.type() == WorldPos.Coordinate.Type.RELATIVE ? RELATIVE_SYMBOL : ABSOLUTE_SYMBOL) + coordinate.value();
+      if (coordinate.type() == WorldPos.Coordinate.Type.RELATIVE) {
+        if (coordinate.value() == 0) {
+          return RELATIVE_SYMBOL;
+        }
+        return RELATIVE_SYMBOL + coordinate.value();
+      }
+      return String.valueOf(coordinate.value());
     }
   }
 }

--- a/api/src/test/java/net/kyori/adventure/text/BlockNBTComponentTest.java
+++ b/api/src/test/java/net/kyori/adventure/text/BlockNBTComponentTest.java
@@ -93,6 +93,22 @@ class BlockNBTComponentTest extends AbstractNBTComponentTest<BlockNBTComponent, 
   }
 
   @Test
+  void testShorthandLocalPosParsing() {
+    assertEquals(
+      BlockNBTComponent.LocalPos.localPos(0.0d, 0.8d, 0.0d),
+      BlockNBTComponent.Pos.fromString("^ ^.8 ^")
+    );
+  }
+
+  @Test
+  void testLocalPosSerialize() {
+    assertEquals(
+      "^ ^0.8 ^32.0",
+      BlockNBTComponent.Pos.fromString("^ ^0.8 ^32.0").asString()
+    );
+  }
+
+  @Test
   void testAbsoluteWorldPosParsing() {
     assertEquals(
       BlockNBTComponent.WorldPos.worldPos(BlockNBTComponent.WorldPos.Coordinate.absolute(4), BlockNBTComponent.WorldPos.Coordinate.absolute(5), BlockNBTComponent.WorldPos.Coordinate.absolute(6)),
@@ -129,6 +145,30 @@ class BlockNBTComponentTest extends AbstractNBTComponentTest<BlockNBTComponent, 
     assertEquals(
       BlockNBTComponent.WorldPos.worldPos(BlockNBTComponent.WorldPos.Coordinate.relative(-6), BlockNBTComponent.WorldPos.Coordinate.absolute(-34), BlockNBTComponent.WorldPos.Coordinate.relative(13)),
       BlockNBTComponent.Pos.fromString("~-6 -34 ~13")
+    );
+  }
+
+  @Test
+  void testFloatingWorldPosParsing() {
+    assertEquals(
+      BlockNBTComponent.WorldPos.worldPos(BlockNBTComponent.WorldPos.Coordinate.relative(0), BlockNBTComponent.WorldPos.Coordinate.absolute(83), BlockNBTComponent.WorldPos.Coordinate.relative(900)),
+      BlockNBTComponent.Pos.fromString("~.6 83 ~900.34")
+    );
+  }
+
+  @Test
+  void testShorthandRelativePosParsing() {
+    assertEquals(
+      BlockNBTComponent.WorldPos.worldPos(BlockNBTComponent.WorldPos.Coordinate.relative(0), BlockNBTComponent.WorldPos.Coordinate.relative(0), BlockNBTComponent.WorldPos.Coordinate.absolute(568)),
+      BlockNBTComponent.Pos.fromString("~ ~ 568")
+    );
+  }
+
+  @Test
+  void testWorldPosSerialize() {
+    assertEquals(
+      "~ ~5 50",
+      BlockNBTComponent.Pos.fromString("~ ~5 50").asString()
     );
   }
 }


### PR DESCRIPTION
This PR makes a few fixes to the parsing of positions in `BlockNBTComponent#fromString`.

The `LOCAL_PATTERN` regex has been modified to allow matching coordinates without a suffixing number, i.e. just `^` instead of `^0.0`:

```diff
- \^(-?\d+(\.\d+)?)
+ \^(-?(\d+)?(\.\d+)?)?
```

It now also allows matching a number between -1 and 1 without a leading `0`, e.g. `^.5` or `^-.5`.

Similarly, the `WORLD_PATTERN` regex has been modified to allow matching relative coordinates without a suffixing number, and to allow matching a suffixing number between -1 and 1 without a leading `0`:

```diff
- (~?)(-?\d+)
+ ((-?\d+)|(~(-?(\d+)?(\.\d+)?)?))
```

Note that the `WORLD_PATTERN` regex now also allows matching relative coordinates with floating-point numbers. This matches vanilla, Minecraft Java Edition behaviour. The coordinates are rounded down into an `int`, although, this should technically only happen once the relative coordinates are resolved into an absolute coordinate. This would, however, mean an API breaking change to `WorldPos`, which is why this hasn't been implemented (see Minecraft's [`Coordinates`](https://mcsrc.dev/2/26.2/net/minecraft/commands/arguments/coordinates/Coordinates#L13-15) interface, which `BlockDataSource` uses, which uses `BlockPos#containing` to floor the coordinates into a block position).

Absolute coordinates are *not* allowed to be floating-point numbers in Java Edition (for block positions, that is), and as such the changes in this PR only allows relative coordinates to be floating-point.

Similar changes have been made to the results of the `Pos#asString` method: it now doesn't include a suffixing number if that number is 0 (`^` instead of `^0.0`).

Tests have been added for all of the above cases. You can verify that vanilla Minecraft Java Edition allows the parsing of any of these coordinates as well, by running the following commands (note that they execute without errors):

- `/tellraw @s {nbt:Items,block:"~ ~ ~"}`
- `/tellraw @s {nbt:Items,block:"^ ^ ^"}`
- `/tellraw @s {nbt:Items,block:"^ ^.5 ^-.3"}`
- `/tellraw @s {nbt:Items,block:"~5.3 50 ~-.1"}`

All these have been tested on Minecraft 26.2. The current implementation of `BlockNBTComponent#fromString`, in Adventure 5.2.0, does not allow parsing any of these. 